### PR TITLE
Multiline Regex handling multiple key-value pairs

### DIFF
--- a/src/main/groovy/com/rundeck/plugin/DataKeyFilterMultiLines.groovy
+++ b/src/main/groovy/com/rundeck/plugin/DataKeyFilterMultiLines.groovy
@@ -120,7 +120,12 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
                         }
 
                         if (key && value) {
-                            allData[key] = value
+
+                            if(allData[key] == null ) {
+                                allData[key] = value
+                            } else {
+                                allData[key] = allData[key] + System.getProperty("line.separator") + value
+                            }
                             outputContext.addOutput("data", key, value)
                         }
                     }

--- a/src/main/groovy/com/rundeck/plugin/DataKeyFilterMultiLines.groovy
+++ b/src/main/groovy/com/rundeck/plugin/DataKeyFilterMultiLines.groovy
@@ -100,25 +100,29 @@ See the [Java Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex
     void complete(final PluginLoggingContext context) {
 
         if(buffer.size()>0){
-            Matcher match = dataPattern.matcher(buffer.toString())
 
-            if (match.matches()) {
-                def key,value
+            for (String line : buffer.toString().split((System.getProperty("line.separator")))) {
 
-                if(match.groupCount()>0){
-                    if(match.groupCount()==1 && name){
-                        key = name
-                        value = match.group(1)
-                    }else {
-                        if(match.groupCount()>1){
-                            key = match.group(1)
-                            value = match.group(2)
+                Matcher match = dataPattern.matcher(line)
+
+                if (match.matches()) {
+                    def key, value
+
+                    if (match.groupCount() > 0) {
+                        if (match.groupCount() == 1 && name) {
+                            key = name
+                            value = match.group(1)
+                        } else {
+                            if (match.groupCount() > 1) {
+                                key = match.group(1)
+                                value = match.group(2)
+                            }
                         }
-                    }
 
-                    if (key && value) {
-                        allData[key] = value
-                        outputContext.addOutput("data", key, value)
+                        if (key && value) {
+                            allData[key] = value
+                            outputContext.addOutput("data", key, value)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This enhancement/fix allow for identifying multiple matches against the multi-line output.  Example:
With raw, output of 
```
Status:
Open 10
Closed 21
Pending 3
```
And a regex pattern of (\w+)\s(\d+), the data variables will now be:
```
$data.Open = 10
$data.Closed = 21
$data.Pending = 3
```
![Screen Shot 2022-02-10 at 4 59 56 PM](https://user-images.githubusercontent.com/11511251/153522196-7339c47c-9cf3-47e7-acfe-3a8b35d68dcd.png)

