### PR TITLE
RUN-660: Add new feature to the plugin so that it can capture multiple key-value pairs for each matched line

### DIFF
--- a/src/test/groovy/com/rundeck/plugin/DataKeyFilterMultiLinesSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugin/DataKeyFilterMultiLinesSpec.groovy
@@ -120,4 +120,64 @@ class DataKeyFilterMultiLinesSpec extends Specification {
                                                          '',
                                                          'done']  | null
     }
+
+    @Unroll
+    def "multiline-filter-multiple-key-value-pairs"() {
+        given:
+        def plugin = new DataKeyFilterMultiLines()
+        plugin.regex = regex
+        plugin.logData = dolog
+        plugin.name = name
+        plugin.captureMultipleKeysValues = true
+        def sharedoutput = new DataOutput(ContextView.global())
+        def context = Mock(PluginLoggingContext) {
+            getOutputContext() >> sharedoutput
+        }
+        def events = []
+        lines.each { line ->
+            events << Mock(LogEventControl) {
+                getMessage() >> line
+                getEventType() >> 'log'
+                getLoglevel() >> LogLevel.NORMAL
+            }
+        }
+        when:
+        plugin.init(context)
+        events.each {
+            plugin.handleEvent(context, it)
+        }
+        plugin.complete(context)
+        then:
+
+        sharedoutput.getSharedContext().getData(ContextView.global())?.getData() == (expect ? ['data': expect] : null)
+        if (expect) {
+            if (dolog) {
+                1 * context.log(2, _, _)
+            } else {
+                0 * context.log(*_)
+            }
+        }
+
+
+        where:
+        dolog | name | regex                         | lines    | expect
+        true  | null | "(\\w+)\\s(\\d+)" | ['hello 1',
+                                                        'world 2',
+                                                        'test 456',
+                                                        '',
+                                                        'done'] | [test: "456", hello: "1", world: "2"]
+
+
+        true  | "any_name" | "(\\w+\\s\\d+)" | ['hello 1',
+                                            'world 2',
+                                            'test 456',
+                                            '',
+                                            'done'] | ["any_name": "hello 1\nworld 2\ntest 456"]
+
+        true  | null | "(\\w+\\s\\d+)" | ['hello 1',
+                                            'world 2',
+                                            'test 456',
+                                            '',
+                                            'done'] | null
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rundeckpro/rundeckpro/issues/2264

This PR includes a new option `Capture multiple values`. If true, it will scan each line separately and capture multiple key-value pairs. If false, it will scan all output at once to capture just one key-value pair