### PR TITLE
Complete Snyk fix with automated fallback version management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,32 @@ jobs:
       - name: Get Release Version
         id: get_version
         run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
+      - name: Update Fallback Version in Main Branch
+        run: |
+          # Create a temporary branch from main to update the fallback version
+          git fetch origin main
+          git checkout main
+          git pull origin main
+          
+          echo "Updating fallback version to ${{ steps.get_version.outputs.VERSION }}"
+          echo "# Fallback version for CI environments where Git history is not available" > gradle.properties
+          echo "# This is automatically updated during the release process" >> gradle.properties  
+          echo "fallback.version=${{ steps.get_version.outputs.VERSION }}" >> gradle.properties
+          
+          # Check if there are changes to commit
+          if ! git diff --quiet gradle.properties; then
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git add gradle.properties
+            git commit -m "Update fallback version to ${{ steps.get_version.outputs.VERSION }} [skip ci]"
+            git push origin main
+            echo "Updated fallback version in main branch"
+          else
+            echo "No changes needed to gradle.properties"
+          fi
+          
+          # Switch back to the tag for the rest of the release process
+          git checkout ${{ github.ref_name }}
       - name: Create Release
         id: create_release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./gradlew build
       - name: Get Release Version
         id: get_version
-        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
+        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
       - name: Update Fallback Version in Main Branch
         run: |
           # Create a temporary branch from main to update the fallback version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           
           echo "Updating fallback version to ${{ steps.get_version.outputs.VERSION }}"
           echo "# Fallback version for CI environments where Git history is not available" > gradle.properties
-          echo "# This is automatically updated during the release process" >> gradle.properties  
+          echo "# This should be updated automatically during the release process" >> gradle.properties  
           echo "fallback.version=${{ steps.get_version.outputs.VERSION }}" >> gradle.properties
           
           # Check if there are changes to commit

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,13 @@ scmVersion {
     }
 }
 
-project.version = scmVersion.version
+// Use a fixed version in CI environments where Git history may be incomplete
+if (System.getenv("CI") || System.getenv("GITHUB_ACTIONS")) {
+    project.version = project.property('fallback.version')
+    println "CI environment detected, using fallback version: ${project.version}"
+} else {
+    project.version = scmVersion.version
+}
 
 /**
  * Set this to a comma-separated list of full classnames of your implemented Rundeck

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# Fallback version for CI environments where Git history is not available
+# This should be updated automatically during the release process
+fallback.version=1.1.5


### PR DESCRIPTION
What It Does:
Gets the release version from the tag
Switches to main branch temporarily
Updates gradle.properties with the new fallback version
Commits and pushes the change to main (with [skip ci] to avoid triggering other workflows)
Switches back to the tag to continue the release process
Benefits:
✅ Automatic maintenance: No manual version updates needed
✅ Always current: Fallback version matches the latest release
✅ Safe: Only updates when there are actual changes
✅ Non-disruptive: Uses [skip ci] to avoid triggering other workflows
✅ Reliable: Handles the case where the update isn't needed
How It Works:
When you create a new tag/release (e.g., 1.2.0)
The workflow runs and updates gradle.properties in the main branch with fallback.version=1.2.0
Future Snyk scans will use this current version instead of an outdated one
No manual maintenance required!